### PR TITLE
Add redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,9 @@
 
   # Default build command.
   command = "yarn build"
+
+[[redirects]]
+  from = "/docs/en/*"
+  to = "/docs/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
Add redirects for old site structure `/docs/en/doc.html` to `/docs/doc.html`. The new site doesn't show the `.html`s but this is just beautifying and will be handled automatically
