### PR TITLE
Remove hass.io branding

### DIFF
--- a/docs/quick_start_core.md
+++ b/docs/quick_start_core.md
@@ -6,7 +6,7 @@ sidebar_label: "Getting Start (Home Assistant Core)"
 
 In this quick start guide, we're going to show you how to set up and use [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), a data science environment. JupyterLab is the tool of choice for data scientists around the globe. Using JupyterLab we will run some reports on your own data. All reports are editable so you can quickly start experimenting and exploring more!
 
-This guide explains the installation and setup of JupyterLab and expects a fresh Ubuntu 18.10 installation. However, it should be easy to adapt it for most other platforms. In case you are using [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for supervised installations](https://data.home-assistant.io/docs/quick_start_index.html).
+This guide explains the installation and setup of JupyterLab and expects a fresh Ubuntu 18.10 installation. However, it should be easy to adapt it for most other platforms. In case you are using [Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science](https://data.home-assistant.io/docs/quick_start_index.html).
 
 ## Preparing the system
 

--- a/docs/quick_start_core.md
+++ b/docs/quick_start_core.md
@@ -1,6 +1,6 @@
 ---
-title: "Quick Start to Home Assistant Data Science for non-hass.io users"
-id: "quick-start-non-hassio"
+title: "Quick Start to Home Assistant Data Science for Home Assistant Core users"
+id: "quick-start-core"
 sidebar_label: "Introduction"
 ---
 

--- a/docs/quick_start_core.md
+++ b/docs/quick_start_core.md
@@ -1,12 +1,12 @@
 ---
 title: "Quick Start to Home Assistant Data Science for Home Assistant Core users"
 id: "quick-start-core"
-sidebar_label: "Introduction"
+sidebar_label: "Getting Start (Home Assistant Core)"
 ---
 
 In this quick start guide, we're going to show you how to set up and use [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), a data science environment. JupyterLab is the tool of choice for data scientists around the globe. Using JupyterLab we will run some reports on your own data. All reports are editable so you can quickly start experimenting and exploring more!
 
-This guide explains the installation and setup of JupyterLab and expects a fresh Ubuntu 18.10 installation. However, it should be easy to adapt it for most other platforms. In case you are using [Hass.io](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for hass.io users](https://data.home-assistant.io/docs/quick_start_index.html).
+This guide explains the installation and setup of JupyterLab and expects a fresh Ubuntu 18.10 installation. However, it should be easy to adapt it for most other platforms. In case you are using [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for supervised installations](https://data.home-assistant.io/docs/quick_start_index.html).
 
 ## Preparing the system
 

--- a/docs/quick_start_index.md
+++ b/docs/quick_start_index.md
@@ -1,12 +1,12 @@
 ---
 title: "Quick Start to Home Assistant Data Science"
 id: "quick-start"
-sidebar_label: "Getting Start (Supervised Installations)"
+sidebar_label: "Getting Started"
 ---
 
 In this quick start guide, we're going to show you how to set up and use [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), a data science environment. JupyterLab is the tool of choice for data scientists around the globe. Using JupyterLab we will run some reports on your own data. All reports are editable so you can quickly start experimenting and exploring more!
 
-This guide is assuming that you have [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/) up and running, this means you have a Supervisor button on the sidebar and can install Add-Ons. Home Assistant is out all-in-one platform and can easily be extended with other software, like JupyterLab. In case you are not using [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for Home Assistant Core users](quick-start-non-hassio).
+This guide is assuming that you are running have [Home Assistant](https://www.home-assistant.io/getting-started/) not [Home Assistant Core](https://www.home-assistant.io/docs/installation/) (see [here](https://www.home-assistant.io/faq/ha-vs-hassio/) for a summary of the differences). Home Assistant is out all-in-one platform and can easily be extended with other software, like JupyterLab. In case you are not using [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for Home Assistant Core users](quick-start-non-hassio).
 
 ## Installing JupyterLab
 

--- a/docs/quick_start_index.md
+++ b/docs/quick_start_index.md
@@ -6,13 +6,13 @@ sidebar_label: "Getting Start (Supervised Installations)"
 
 In this quick start guide, we're going to show you how to set up and use [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), a data science environment. JupyterLab is the tool of choice for data scientists around the globe. Using JupyterLab we will run some reports on your own data. All reports are editable so you can quickly start experimenting and exploring more!
 
-This guide is assuming that you have [a Hass.io installation](https://www.home-assistant.io/getting-started/) up and running. Hass.io is our all-in-one platform that runs Home Assistant and can easily be extended with other software, like JupyterLab. In case you are not using [Hass.io](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for non-hass.io users](quick-start-non-hassio).
+This guide is assuming that you have [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/) up and running, this means you have a Supervisor button on the sidebar and can install Add-Ons. Home Assistant is out all-in-one platform and can easily be extended with other software, like JupyterLab. In case you are not using [a supervised installation of Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for Home Assistant Core users](quick-start-non-hassio).
 
 ## Installing JupyterLab
 
 To install JupyterLab, we're going to use the JupyterLab Lite add-on by the Community Add-ons project. To get started:
 
-- Click on Hass.io in the panel. Choose "Add-On Store" from the menu.
+- Click on Supervisor in the panel. Choose "Add-On Store" from the menu.
 - Add the Community Add-ons as a new repository with the URL `https://github.com/hassio-addons/repository` and click on "Add".
 - Scroll down to the new section for Community Add-ons and click the install button on **JupyterLab Lite**. Installation can take a couple of minutes depending on your internet speed.
 - Once installed, it will open the JupyterLab Lite add-on page.

--- a/docs/quick_start_index.md
+++ b/docs/quick_start_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Quick Start to Home Assistant Data Science"
 id: "quick-start"
-sidebar_label: "Introduction"
+sidebar_label: "Getting Start (Supervised Installations)"
 ---
 
 In this quick start guide, we're going to show you how to set up and use [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), a data science environment. JupyterLab is the tool of choice for data scientists around the globe. Using JupyterLab we will run some reports on your own data. All reports are editable so you can quickly start experimenting and exploring more!

--- a/docs/quick_start_index.md
+++ b/docs/quick_start_index.md
@@ -8,8 +8,6 @@ In this quick start guide, we're going to show you how to set up and use [Jupyte
 
 This guide is assuming that you have [a Hass.io installation](https://www.home-assistant.io/getting-started/) up and running. Hass.io is our all-in-one platform that runs Home Assistant and can easily be extended with other software, like JupyterLab. In case you are not using [Hass.io](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science for non-hass.io users](quick-start-non-hassio).
 
-If you don't use Hass.io to run Home Assistant, skip the next step and manually install [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), [HASS Data Detective](https://pypi.org/project/HASS-data-detective/) and download the [Home Assistant notebooks](https://github.com/home-assistant/home-assistant-notebooks).
-
 ## Installing JupyterLab
 
 To install JupyterLab, we're going to use the JupyterLab Lite add-on by the Community Add-ons project. To get started:

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,6 +8,6 @@
 module.exports = {
   docs: {
     Data: ['data', 'events', 'states', 'services', 'context', 'recorder'],
-    'Start Exploring': ['quick-start'],
+    'Start Exploring': ['quick-start', 'quick-start-core'],
   },
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,7 +29,7 @@ const features = [
         <b><a href='/docs/quick-start'>Quick Start Guide.</a></b>
         {' '}In 15 minutes you will set up a data science environment and run your first reports.
         <br />
-        <b><a href='/docs/quick-start-non-hassio'>Quick Start Guide for non-hass.io users.</a></b>
+        <b><a href='/docs/quick-start-non-hassio'>Quick Start Guide for Home Assistant Core users.</a></b>
         {' '}In 15 minutes you will set up a data science environment and run your first reports.
       </>
     ),

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,7 +29,7 @@ const features = [
         <b><a href='/docs/quick-start'>Quick Start Guide.</a></b>
         {' '}In 15 minutes you will set up a data science environment and run your first reports.
         <br />
-        <b><a href='/docs/quick-start-non-hassio'>Quick Start Guide for Home Assistant Core users.</a></b>
+        <b><a href='/docs/quick-start-core'>Quick Start Guide for Home Assistant Core users.</a></b>
         {' '}In 15 minutes you will set up a data science environment and run your first reports.
       </>
     ),

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,4 @@
+# Processed by Netlify BEFORE netlify.toml file
+
+# Format is: From To
+/docs/quick-start-non-hassio /docs/quick-start-core


### PR DESCRIPTION
Removes the use of terms like hass.io and non-hass.io. In general I have replaced these with Home assistant and Home Assistant Core but I do emphasise the supervised installation for the former.

Also adds an _redirects file to catch the file name change