### PR TITLE
Update the "Getting Started notebook" URL

### DIFF
--- a/blog/2018-12-27-data-science-for-home-assistant-launched.md
+++ b/blog/2018-12-27-data-science-for-home-assistant-launched.md
@@ -20,7 +20,7 @@ The Home Assistant Data Science website is your one-stop-shop for advice on gett
 
 We have also created a Python library called the [HASS-Data-Detective](https://github.com/robmarkcole/HASS-data-detective) which makes it super easy to get started investigating your Home Assistant data using modern data science tools such as [Pandas](https://pandas.pydata.org/).
 
-To tie it all together, we created a [Getting Started notebook](https://github.com/home-assistant/home-assistant-notebooks/blob/master/~%20GETTING%20STARTED.ipynb) which shows you how to do some elementary analysis on your Home Assistant data. In 15 minutes, you can install the Jupyerlab Lite add-on and generate a report on your own data. [Try it out](/docs/quick-start).
+To tie it all together, we created a [Getting Started notebook](https://nbviewer.jupyter.org/github/home-assistant/home-assistant-notebooks/blob/master/GETTING_STARTED.ipynb) which shows you how to do some elementary analysis on your Home Assistant data. In 15 minutes, you can install the Jupyerlab Lite add-on and generate a report on your own data. [Try it out](/docs/quick-start).
 
 Going forward, we are planning on publishing more articles here showing how you can do more advanced analysis on your Home Assistant data, show how this can feedback into your automations and highlight creations of the community.
 


### PR DESCRIPTION
This pull request proposes to update the "Getting Started notebook" URL on the ["Data Science portal for Home Assistant launched" blog post](https://data.home-assistant.io/blog/2018/12/27/data-science-for-home-assistant-launched).

The proposed change will change the URL from https://github.com/home-assistant/home-assistant-notebooks/blob/master/~%20GETTING%20STARTED.ipynb to https://nbviewer.jupyter.org/github/home-assistant/home-assistant-notebooks/blob/master/GETTING_STARTED.ipynb