### PR TITLE
Update the "quick start to Home Assistant Data Science" URL

### DIFF
--- a/docs/quick_start_core.md
+++ b/docs/quick_start_core.md
@@ -6,7 +6,7 @@ sidebar_label: "Getting Start (Home Assistant Core)"
 
 In this quick start guide, we're going to show you how to set up and use [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), a data science environment. JupyterLab is the tool of choice for data scientists around the globe. Using JupyterLab we will run some reports on your own data. All reports are editable so you can quickly start experimenting and exploring more!
 
-This guide explains the installation and setup of JupyterLab and expects a fresh Ubuntu 18.10 installation. However, it should be easy to adapt it for most other platforms. In case you are using [Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science](https://data.home-assistant.io/docs/quick_start_index.html).
+This guide explains the installation and setup of JupyterLab and expects a fresh Ubuntu 18.10 installation. However, it should be easy to adapt it for most other platforms. In case you are using [Home Assistant](https://www.home-assistant.io/getting-started/), please check out the [quick start to Home Assistant Data Science](/docs/quick-start).
 
 ## Preparing the system
 


### PR DESCRIPTION
This proposed change will update the "quick start to Home Assistant Data Science" URL on the ["Getting Start (Home Assistant Core)" page](https://data.home-assistant.io/docs/quick-start-core/).

This proposed change will update the URL from https://data.home-assistant.io/docs/quick_start_index.html to https://data.home-assistant.io/docs/quick-start