### PR TITLE
Add doc index redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -2,3 +2,4 @@
 
 # Format is: From To
 /docs/quick-start-non-hassio /docs/quick-start-core
+/docs /docs/data


### PR DESCRIPTION
Docusaurus V2 alpha 58 included a breaking change that it no longer builds a duplicate page for `/docs`. This PR just adds a redirect to cover any links remaining to that address
