### PR TITLE
Add HA logo to home page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -82,22 +82,29 @@ function Home() {
       description="Explore the data of your home">
       <header className={classnames('hero hero--primary', styles.heroBanner)}>
         <div className="container">
-          <h1 className="hero__title">{siteConfig.title}</h1>
-          <p className="hero__subtitle">{siteConfig.tagline}</p>
-          <p>
-            <a className="hero__text" href="https://www.home-assistant.io">
-              Not a data scientist? Go to the normal website
-            </a>
-          </p>
-          <div className={styles.buttons}>
-            <Link
-              className={classnames(
-                'button button--outline button--secondary button--lg',
-                styles.getStarted,
-              )}
-              to={useBaseUrl('docs/quick-start')}>
-              Get Started
-            </Link>
+          <div className="row">
+            <div className={classnames('col col--5')}>
+              <img className={styles.heroLogo} alt="Home Assistant Logo" src="/img/logo-white.svg" />
+            </div>
+            <div className={classnames('col col--5')}>
+              <h1 className={styles.heroTitle}>{siteConfig.title}</h1>
+              <p className={styles.heroTagline}>{siteConfig.tagline}</p>
+              <p>
+                <a className={styles.heroText} href="https://www.home-assistant.io">
+                  Not a data scientist? Go to the normal website
+                </a>
+              </p>
+              <div className={styles.buttons}>
+                <Link
+                  className={classnames(
+                    'button button--outline button--secondary button--lg',
+                    styles.getStarted,
+                  )}
+                  to={useBaseUrl('docs/quick-start')}>
+                  Get Started
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
       </header>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -33,3 +33,28 @@
   height: 200px;
   width: 200px;
 }
+
+a.heroText{
+  color: #ffffff;
+}
+
+.heroTitle {
+  font-size: 3rem;
+  color: #ffffff;
+}
+
+.heroTagline {
+  font-size: 1.4rem;
+  color: #ffffff;
+}
+
+.heroLogo {
+  max-height: 16em;
+}
+
+.getStarted {
+  color: #ffffff !important;
+}
+.getStarted:hover {
+  color: #000000 !important;
+}


### PR DESCRIPTION
Adds the Home Assistant logo to the main banner on the home page.

As per the similar PRs home-assistant/companion.home-assistant#341 and home-assistant/developers.home-assistant#658 the banner contents are immune from changes when switching to/from dark mode.

I have a better idea for site specific logos but need to find some time to draw and see if they work. In the mean time this improves (IMO) the landing page a bit