### PR TITLE
Bump docusaurus core to beta 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "by-node-env": "^2.0.1",
-    "@docusaurus/core": "^2.0.0-beta.3",
+    "@docusaurus/core": "^2.0.0-beta.4",
     "@docusaurus/preset-classic": "^2.0.0-beta.4",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,7 +1371,7 @@
     "@docsearch/css" "3.0.0-alpha.39"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.0-beta.4", "@docusaurus/core@^2.0.0-beta.3":
+"@docusaurus/core@2.0.0-beta.4", "@docusaurus/core@^2.0.0-beta.4":
   version "2.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-beta.4.tgz#b41c5064c8737405cfceb1a373c9c5aa3410fd95"
   integrity sha512-ITa976MPFl9KbYchMOWCCX6SU6EFDSdGeGOHtpaNcrJ9e9Sj7o77fKmMH/ciShwz1g8brTm3VxZ0FwleU8lTig==


### PR DESCRIPTION
Bump docusaurus core to beta 4 (missed by bot/merged PRs in wrong order). Core is a dependency of preset-classic but interestingly other dependencies of core have been bumped here which weren't bumped in the preset-classic PR