### PR TITLE
Updates for schema v36

### DIFF
--- a/docs/data_events.md
+++ b/docs/data_events.md
@@ -59,17 +59,17 @@ Note, a user doesn't always wait for Home Assistant to gracefully shut down and 
 
 All events are stored in the database in a table named `events`. The important fields for the events table are `event_type`, `time_fired_ts` and `context_id`. That information can be used to figure out what happened when, and how it related to other events.
 
-| Field             | Type                                                          |
-| ----------------- | ------------------------------------------------------------- |
-| event_id          | Column(Integer, primary_key=True)                             |
-| event_type        | Column(String(32))                                            |
-| event_data        | Column(Text)                                                  |
-| origin_idx        | Column(Integer)                                               |
-| time_fired_ts     | Column(Float, index=True)                                     |
-| context_id        | Column(String(36), index=True)                                |
-| context_user_id   | Column(String(36))                                            |
-| context_parent_id | Column(String(36))                                            |
-| data_id           | Column(Integer, ForeignKey("event_data.data_id"), index=True) |
+| Field                 | Type                                                          |
+| --------------------- | ------------------------------------------------------------- |
+| event_id              | Column(Integer, primary_key=True)                             |
+| event_type            | Column(String(32))                                            |
+| event_data            | Column(Text)                                                  |
+| origin_idx            | Column(Integer)                                               |
+| time_fired_ts         | Column(Float, index=True)                                     |
+| context_id_bin        | Column(Blob(16), index=True)                                  |
+| context_user_id_bin   | Column(Blob(16))                                              |
+| context_parent_id_bin | Column(Blob(16))                                              |
+| data_id               | Column(Integer, ForeignKey("event_data.data_id"), index=True) |
 
 Further details about the [database schema](https://www.home-assistant.io/docs/backend/database/#schema) are available in the official documentation.
 
@@ -107,4 +107,12 @@ For events that were recorded after the `event_data` table was created, the data
 
 ```sql
 SELECT * FROM events LEFT JOIN event_data ON (events.data_id=event_data.data_id);
+```
+
+### Viewing the context data
+
+#### SQLite context data example
+
+```sql
+select event_id, event_type, datetime(time_fired_ts, 'unixepoch', 'localtime'), hex(context_id_bin), hex(context_parent_id_bin) from events;
 ```

--- a/docs/data_states.md
+++ b/docs/data_states.md
@@ -16,20 +16,20 @@ The difference between `last_changed_ts` and `last_updated_ts` is that `last_cha
 
 The `last_changed_ts` field is not stored in the database when it is the same as the `last_updated_ts` field. See [Fetching the last_changed_ts when it is NULL](#fetching-the-last_changed_ts-when-it-is-null) for queries to populate the value when it is NULL.
 
-| Field             | Type                                                                      |
-| ----------------- | ------------------------------------------------------------------------- |
-| state_id          | Column(Integer, primary_key=True)                                         |
-| entity_id         | Column(String(255))                                                       |
-| state             | Column(String(255))                                                       |
-| event_id          | Column(Integer, ForeignKey('events.event_id'), index=True)                |
-| last_changed_ts   | Column(Float)                                                             |
-| last_updated_ts   | Column(Float, default=time.time, index=True)                              |
-| old_state_id      | Column(Integer, ForeignKey("states.state_id"), index=True)                |
-| attributes_id     | Column(Integer, ForeignKey("state_attributes.attributes_id"), index=True) |
-| context_id        | Column(String(36), index=True)                                            |
-| context_user_id   | Column(String(36))                                                        |
-| context_parent_id | Column(String(36))                                                        |
-| origin_idx        | Column(Integer)                                                           |
+| Field                 | Type                                                                      |
+| --------------------- | ------------------------------------------------------------------------- |
+| state_id              | Column(Integer, primary_key=True)                                         |
+| entity_id             | Column(String(255))                                                       |
+| state                 | Column(String(255))                                                       |
+| event_id              | Column(Integer, ForeignKey('events.event_id'), index=True)                |
+| last_changed_ts       | Column(Float)                                                             |
+| last_updated_ts       | Column(Float, default=time.time, index=True)                              |
+| old_state_id          | Column(Integer, ForeignKey("states.state_id"), index=True)                |
+| attributes_id         | Column(Integer, ForeignKey("state_attributes.attributes_id"), index=True) |
+| context_id_bin        | Column(Blob(16), index=True)                                              |
+| context_user_id_bin   | Column(Blob(16))                                                          |
+| context_parent_id_bin | Column(Blob(16))                                                          |
+| origin_idx            | Column(Integer)                                                           |
 
 The `created` field is no longer stored in the `states` table to avoid duplicating data in the database as it was always the same as `last_updated_ts` and the matching `state_change` event's `time_fired_ts`.
 


### PR DESCRIPTION
Core change: https://github.com/home-assistant/core/pull/88942

- context ids are now 16 bytes
- example query to view context ids