### PR TITLE
Correct stale information that was missed with previous schema changes

### DIFF
--- a/docs/data_context.md
+++ b/docs/data_context.md
@@ -25,14 +25,14 @@ Context is not stored in their own table in the database. Instead, each event ro
 
 ## Example queries
 
-### Finding the `context_id` for a `state` in the database.
+### Finding the `context_id` for a `state_changed` event in the database.
 
 ```sql
-SELECT states.entity_id, states.state, events.context_id, events.context_user_id, events.context_parent_id FROM states LEFT JOIN events ON states.event_id = events.event_id
+SELECT states_meta.entity_id, states.state, hex(states.context_id_bin), hex(states.context_user_id_bin), hex(states.context_parent_id_bin) FROM states LEFT JOIN states_meta ON (states.metadata_id=states_meta.metadata_id);
 ```
 
 ### Finding the `context_id` for an `event` in the database.
 
 ```sql
-SELECT events.event_type, events.event_data, events.context_id, events.context_user_id, events.context_parent_id FROM events
+SELECT event_types.event_type, event_data.shared_data, hex(events.context_id_bin), hex(events.context_user_id_bin), hex(events.context_parent_id_bin) FROM events  LEFT JOIN event_data ON (events.data_id=event_data.data_id) LEFT JOIN event_types ON (events.event_type_id=event_types.event_type_id);
 ```

--- a/docs/data_events.md
+++ b/docs/data_events.md
@@ -120,7 +120,7 @@ SELECT * FROM events LEFT JOIN event_data ON (events.data_id=event_data.data_id)
 #### SQLite context data example
 
 ```sql
-select event_id, event_type, datetime(time_fired_ts, 'unixepoch', 'localtime'), hex(context_id_bin), hex(context_parent_id_bin) from events;
+SELECT event_id, event_type, DATETIME(time_fired_ts, 'unixepoch', 'localtime'), hex(context_id_bin), hex(context_parent_id_bin) FROM events;
 ```
 
 ### Viewing event data in a human readable format
@@ -130,17 +130,17 @@ The below example queries make it easier to review data in the `events` table in
 #### SQLite human readable example
 
 ```sql
-select event_id, datetime(time_fired_ts, 'unixepoch', 'localtime'), event_types.event_type, shared_data, hex(context_id_bin) from events left join event_data on (events.data_id=event_data.data_id) left join event_types on (events.event_type_id=event_types.event_type_id)
+SELECT event_id, DATETIME(time_fired_ts, 'unixepoch', 'localtime'), event_types.event_type, shared_data, hex(context_id_bin) FROM events LEFT JOIN event_data ON (events.data_id=event_data.data_id) LEFT JOIN event_types ON (events.event_type_id=event_types.event_type_id)
 ```
 
 #### MariaDB human readable example
 
 ```sql
-select event_id, from_unixtime(time_fired_ts), event_types.event_type, shared_data, hex(context_id_bin) from events left join event_data on (events.data_id=event_data.data_id) left join event_types on (events.event_type_id=event_types.event_type_id)
+SELECT event_id, from_unixtime(time_fired_ts), event_types.event_type, shared_data, hex(context_id_bin) FROM events LEFT JOIN event_data on (events.data_id=event_data.data_id) LEFT JOIN event_types ON (events.event_type_id=event_types.event_type_id)
 ```
 
 #### PostgreSQL human readable example
 
 ```sql
-select event_id, to_timestamp(time_fired_ts), event_types.event_type, shared_data, context_id_bin from events left join event_data on (events.data_id=event_data.data_id) left join event_types on (events.event_type_id=event_types.event_type_id);
+SELECT event_id, to_timestamp(time_fired_ts), event_types.event_type, shared_data, context_id_bin FROM events LEFT JOIN event_data on (events.data_id=event_data.data_id) LEFT JOIN event_types ON (events.event_type_id=event_types.event_type_id);
 ```

--- a/docs/data_statistics.md
+++ b/docs/data_statistics.md
@@ -56,7 +56,7 @@ This table contains the actual data. Depending on the entity type, different dat
 | mean | Column(DOUBLE_TYPE())
 | min | Column(DOUBLE_TYPE())
 | max | Column(DOUBLE_TYPE())
-| last_reset | Column(DATETIME_TYPE)
+| last_reset_ts | Column(DOUBLE_TYPE())
 | state | Column(DOUBLE_TYPE())
 | sum | Column(DOUBLE_TYPE())
 


### PR DESCRIPTION
- Update context queries to work with latest schema
- Correct name of Statistics columns
- Cleanup example queries